### PR TITLE
Remove VS Code settings from the repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "main.C": "cpp"
-    }
-}


### PR DESCRIPTION
Removed VS Code settings from the repository to avoid tracking .vscode/settings.json. Added .vscode/ to .gitignore to prevent future commits of these files